### PR TITLE
Optimizaciones

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,10 @@ tasks.register<JacocoReport>("jacocoUnitTestReport") {
                 "**/ui/performers/PerformerViewModel\$*.class",
                 "**/ui/performers/PerformerDetailViewModel.class",
                 "**/ui/performers/PerformerDetailViewModel\$*.class",
+                "**/ui/collectors/CollectorsViewModel.class",
+                "**/ui/collectors/CollectorsViewModel\$*.class",
+                "**/ui/collectors/CollectorDetailViewModel.class",
+                "**/ui/collectors/CollectorDetailViewModel\$*.class",
             )
         }
     )

--- a/app/src/androidTest/java/com/misw/vinilos/albums/AlbumDetailE2ETest.kt
+++ b/app/src/androidTest/java/com/misw/vinilos/albums/AlbumDetailE2ETest.kt
@@ -15,6 +15,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.misw.vinilos.MainActivity
 import com.misw.vinilos.R
+import com.misw.vinilos.testutils.EspressoIdlingRule
 import org.hamcrest.CoreMatchers.not
 import org.junit.Before
 import org.junit.FixMethodOrder
@@ -30,12 +31,13 @@ class AlbumDetailE2ETest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
+    @get:Rule
+    val idlingRule = EspressoIdlingRule()
+
     @Before
     fun navegarAlDetalle() {
-        Thread.sleep(8000)
         onView(withId(R.id.rvAlbums))
             .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
-        Thread.sleep(5000)
     }
 
     @Test

--- a/app/src/androidTest/java/com/misw/vinilos/albums/AlbumListE2ETest.kt
+++ b/app/src/androidTest/java/com/misw/vinilos/albums/AlbumListE2ETest.kt
@@ -9,8 +9,8 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.misw.vinilos.MainActivity
 import com.misw.vinilos.R
+import com.misw.vinilos.testutils.EspressoIdlingRule
 import com.misw.vinilos.utils.RecyclerViewMatcher
-import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Rule
 import org.junit.Test
@@ -24,10 +24,8 @@ class AlbumListE2ETest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
-    @Before
-    fun esperarCargaInicial() {
-        Thread.sleep(8000)
-    }
+    @get:Rule
+    val idlingRule = EspressoIdlingRule()
 
     @Test
     fun e2e_hu01_01_albumList_seVisualizaAlAbrir() {

--- a/app/src/androidTest/java/com/misw/vinilos/collectors/CollectorDetailE2ETest.kt
+++ b/app/src/androidTest/java/com/misw/vinilos/collectors/CollectorDetailE2ETest.kt
@@ -17,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.misw.vinilos.MainActivity
 import com.misw.vinilos.R
 import com.misw.vinilos.ui.collectors.CollectorAdapter
+import com.misw.vinilos.testutils.EspressoIdlingRule
 import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Rule
@@ -31,20 +32,18 @@ class CollectorDetailE2ETest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
+    @get:Rule
+    val idlingRule = EspressoIdlingRule()
+
     @Before
     fun esperarCargaInicial() {
-        // Tests existentes usan sleep; mantenemos consistencia.
-        Thread.sleep(8000)
+        // Sin esperas activas: Espresso sincroniza con red vía IdlingResource.
     }
 
     @Test
     fun e2e_hu05_01_collectorsList_seVisualizaAlAbrirTab() {
         onView(withId(R.id.bottomNavigation)).check(matches(isDisplayed()))
         onView(withId(R.id.CollectorsFragment)).perform(click())
-
-        // La pantalla puede mostrar loader y luego lista o empty state dependiendo del backend.
-        // Esperamos (de forma simple, consistente con el resto de E2E) a que termine la carga.
-        Thread.sleep(6000)
 
         // Debe mostrarse la lista o el empty state; con cualquiera el tab se considera correcto.
         // Si hay lista, rvCollectors será visible.
@@ -60,9 +59,6 @@ class CollectorDetailE2ETest {
     fun e2e_hu05_02_clickCollector_navegaADetalle() {
         onView(withId(R.id.CollectorsFragment)).perform(click())
 
-        // Esperar carga
-        Thread.sleep(6000)
-
         // Este test aplica sólo si hay al menos un collector. Si no hay datos (empty state),
         // validamos que el empty state sea visible y no intentamos hacer click.
         try {
@@ -76,7 +72,6 @@ class CollectorDetailE2ETest {
             onView(withId(R.id.tvCollectorDetailEmail)).check(matches(isDisplayed()))
 
             // Validación básica de contenido no-vacío (evita pasar si queda en blanco por render asíncrono)
-            Thread.sleep(1500)
             onView(withId(R.id.tvCollectorDetailTitle)).check(matches(not(withText(""))))
 
             // Nueva sección: Favorite performers (puede venir con datos o vacío según backend)

--- a/app/src/androidTest/java/com/misw/vinilos/collectors/CollectorsEmptyStateE2ETest.kt
+++ b/app/src/androidTest/java/com/misw/vinilos/collectors/CollectorsEmptyStateE2ETest.kt
@@ -11,6 +11,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.misw.vinilos.MainActivity
 import com.misw.vinilos.R
+import com.misw.vinilos.testutils.EspressoIdlingRule
 import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Rule
@@ -25,15 +26,17 @@ class CollectorsEmptyStateE2ETest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
+    @get:Rule
+    val idlingRule = EspressoIdlingRule()
+
     @Before
     fun esperarCargaInicial() {
-        Thread.sleep(8000)
+        // Sin esperas activas: Espresso sincroniza con red vía IdlingResource.
     }
 
     @Test
     fun e2e_hu05_03_emptyState_noDebeVerseSiHayLista() {
         onView(withId(R.id.CollectorsFragment)).perform(click())
-        Thread.sleep(3000)
 
         // En ambiente real normalmente hay coleccionistas; entonces el empty state debe estar oculto.
         // Si el backend devolviera vacío en algún momento, este test podría fallar (es un E2E).

--- a/app/src/androidTest/java/com/misw/vinilos/performers/PerformerDetailE2ETest.kt
+++ b/app/src/androidTest/java/com/misw/vinilos/performers/PerformerDetailE2ETest.kt
@@ -14,6 +14,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.misw.vinilos.MainActivity
 import com.misw.vinilos.R
+import com.misw.vinilos.testutils.EspressoIdlingRule
 import org.hamcrest.CoreMatchers.not
 import org.junit.Before
 import org.junit.FixMethodOrder
@@ -29,14 +30,14 @@ class PerformerDetailE2ETest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
+    @get:Rule
+    val idlingRule = EspressoIdlingRule()
+
     @Before
     fun navegarAlDetalleDeArtista() {
-        Thread.sleep(3000)
         onView(withId(R.id.PerformerListFragment)).perform(click())
-        Thread.sleep(8000)
         onView(withId(R.id.rvPerformers))
             .perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
-        Thread.sleep(5000)
     }
 
     @Test

--- a/app/src/androidTest/java/com/misw/vinilos/performers/PerformerListE2ETest.kt
+++ b/app/src/androidTest/java/com/misw/vinilos/performers/PerformerListE2ETest.kt
@@ -12,6 +12,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.misw.vinilos.MainActivity
 import com.misw.vinilos.R
+import com.misw.vinilos.testutils.EspressoIdlingRule
 import org.junit.Before
 import org.junit.FixMethodOrder
 import org.junit.Rule
@@ -26,11 +27,12 @@ class PerformerListE2ETest {
     @get:Rule
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
+    @get:Rule
+    val idlingRule = EspressoIdlingRule()
+
     @Before
     fun navegarALaPestanaArtistas() {
-        Thread.sleep(3000)
         onView(withId(R.id.PerformerListFragment)).perform(click())
-        Thread.sleep(8000)
     }
 
     @Test

--- a/app/src/androidTest/java/com/misw/vinilos/testutils/EspressoIdlingRule.kt
+++ b/app/src/androidTest/java/com/misw/vinilos/testutils/EspressoIdlingRule.kt
@@ -1,0 +1,50 @@
+package com.misw.vinilos.testutils
+
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.IdlingResource
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Registra/desregistra el CountingIdlingResource global.
+ *
+ * Al estar enganchado vía OkHttp interceptor, los tests no necesitan Thread.sleep().
+ */
+class EspressoIdlingRule : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                EspressoIdlingResource.resetForTests()
+
+                val idlingResource = object : IdlingResource {
+                    @Volatile
+                    private var callback: IdlingResource.ResourceCallback? = null
+
+                    override fun getName(): String = "VinilosNetwork"
+
+                    override fun isIdleNow(): Boolean {
+                        val idle = EspressoIdlingResource.isIdleNow()
+                        if (idle) {
+                            callback?.onTransitionToIdle()
+                        }
+                        return idle
+                    }
+
+                    override fun registerIdleTransitionCallback(cb: IdlingResource.ResourceCallback) {
+                        callback = cb
+                    }
+                }
+
+                IdlingRegistry.getInstance().register(idlingResource)
+                try {
+                    base.evaluate()
+                } finally {
+                    IdlingRegistry.getInstance().unregister(idlingResource)
+                }
+            }
+        }
+    }
+}
+
+

--- a/app/src/debug/java/com/misw/vinilos/testutils/EspressoIdlingResource.kt
+++ b/app/src/debug/java/com/misw/vinilos/testutils/EspressoIdlingResource.kt
@@ -1,0 +1,37 @@
+package com.misw.vinilos.testutils
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Contador simple usado por la app para notificar “trabajo en curso”.
+ *
+ * Importante:
+ * - Este archivo vive en sourceSet `debug` y NO depende de Espresso.
+ * - Los tests instrumentados (androidTest) registran un IdlingResource propio
+ *   que observa este contador.
+ */
+object EspressoIdlingResource {
+
+    private val counter = AtomicInteger(0)
+
+    fun increment() {
+        counter.incrementAndGet()
+    }
+
+    fun decrement() {
+        // Evitamos negativos por seguridad.
+        while (true) {
+            val current = counter.get()
+            if (current <= 0) return
+            if (counter.compareAndSet(current, current - 1)) return
+        }
+    }
+
+    fun isIdleNow(): Boolean = counter.get() == 0
+
+    fun resetForTests() {
+        counter.set(0)
+    }
+}
+
+

--- a/app/src/main/java/com/misw/vinilos/data/network/EspressoIdlingInterceptor.kt
+++ b/app/src/main/java/com/misw/vinilos/data/network/EspressoIdlingInterceptor.kt
@@ -1,0 +1,23 @@
+package com.misw.vinilos.data.network
+
+import com.misw.vinilos.testutils.EspressoIdlingResource
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Interceptor que notifica a Espresso sobre el inicio/fin de requests HTTP.
+ *
+ * En debug incrementa/decrementa un CountingIdlingResource.
+ * En release es no-op (la implementación de EspressoIdlingResource es no-op).
+ */
+class EspressoIdlingInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        EspressoIdlingResource.increment()
+        return try {
+            chain.proceed(chain.request())
+        } finally {
+            EspressoIdlingResource.decrement()
+        }
+    }
+}
+

--- a/app/src/main/java/com/misw/vinilos/data/network/VinilosServiceAdapter.kt
+++ b/app/src/main/java/com/misw/vinilos/data/network/VinilosServiceAdapter.kt
@@ -45,6 +45,8 @@ object VinilosServiceAdapter {
         val okHttpClient = OkHttpClient.Builder()
             .cache(cache)
             .addNetworkInterceptor(CacheControlInterceptor(maxAgeSeconds = 60))
+            // Sincroniza Espresso con las llamadas de red (en release es no-op)
+            .addInterceptor(EspressoIdlingInterceptor())
             .addInterceptor(logging)
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(20, TimeUnit.SECONDS)

--- a/app/src/release/java/com/misw/vinilos/testutils/EspressoIdlingResource.kt
+++ b/app/src/release/java/com/misw/vinilos/testutils/EspressoIdlingResource.kt
@@ -1,0 +1,17 @@
+package com.misw.vinilos.testutils
+
+/**
+ * Implementación no-op para builds release.
+ *
+ * La app no debería depender de Espresso en release.
+ */
+object EspressoIdlingResource {
+    fun increment() = Unit
+    fun decrement() = Unit
+
+    fun isIdleNow(): Boolean = true
+
+    fun resetForTests() = Unit
+}
+
+


### PR DESCRIPTION
Se realiza optimización en test e2e de expresso para dejar de usar sleep() y usar IdlingResource en su lugar, se aumetna coverage